### PR TITLE
Update: 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Features:
 * Visuals showing Carb and IOB over time and Basal vs Temp Basal adjustments
 * Integration with Nightscout via NSClient and Pump Driver Apps for full Closed Loop operation
 
-As of now the App can be used to inform the user at a user set time interval suggested Temp Basal as calculated by the OpenAPS.org algorithm, this can then be manually set on the users pump.
+App can be used to inform the user at a user set time interval of suggested Temp Basal calculated by the OpenAPS.org algorithm, this can then be manually set on the users pump.
 This allows a Diabetic with any pump to experiment with the OpenAPS algorithm.
 
 Requirements:


### PR DESCRIPTION
Ignore correction bolus for Bolus Snooze for OpenAPS Dev & Master
Clears active notifications on new TBR & update xDrip WF
Added date formatting and last BG readings to debug output
Added omnipod pump profile
Rounding Y axis for Basal Vs Temp Basal Chart
Ability to Cancel TBR from Wear
Added Safety object to Debug
Running Pump temp calculated from TBR start date not current date time
round via Decimal format and not String.format in all functions
ReadMe update

_known issues_
poss IOB dropping to 0 on app restart
